### PR TITLE
Fix MSBUILD error MSB1003

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ensure you have the [.NET SDK](https://dotnet.microsoft.com/download) installed 
 
 ```bash
 # Restore dependencies and build
-dotnet build
+dotnet build src/GuessGame.sln
 
 # Run the game
 dotnet run --project src/GuessGame
@@ -20,4 +20,4 @@ When you run the program you will be asked to guess a number between 1 and 100. 
 
 ## License
 
-This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+This project is licensed under the MIT License. See [src/LICENSE](src/LICENSE) for details.

--- a/src/GuessGame.sln
+++ b/src/GuessGame.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7F19AD22-8ED8-4CC1-95ED-3C0333843BC9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GuessGame", "src\GuessGame\GuessGame.csproj", "{EAF8FFA8-AA83-4CD6-AE62-6DB7E2AE4321}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GuessGame", "GuessGame\GuessGame.csproj", "{EAF8FFA8-AA83-4CD6-AE62-6DB7E2AE4321}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Updated the README build instructions to call dotnet build src/GuessGame.sln and corrected the license link so the instructions work from the repository root

Fixed the solution file so it points to the project using “GuessGame\GuessGame.csproj” instead of the incorrect path

Ensured the source code ends cleanly with a newline character